### PR TITLE
fix: migrations assume flarum is already installed

### DIFF
--- a/migrations/2021_09_12_modify_badwords_delimiter.php
+++ b/migrations/2021_09_12_modify_badwords_delimiter.php
@@ -13,14 +13,14 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
+        $db = $schema->getConnection();
+        $query = $db->table('settings')->where('key', 'fof-filter.words');
+        $result = $query->first();
 
-        if (!empty($words = $settings->get('fof-filter.words', null))) {
-            $words = str_replace(', ', "\n", $words);
-            $settings->set('fof-filter.words', $words);
+        if ($result !== null) {
+            $words = str_replace(', ', "\n", $result->value);
+
+            $query->update(['value' => $words]);
         }
     },
     'down' => function (Builder $schema) {


### PR DESCRIPTION
Relates to https://github.com/flarum/framework/pull/3655

**Changes proposed in this pull request:**
Use Schema DB connection instead of resolving `flarum.settings`. 
More info @ https://github.com/FriendsOfFlarum/reactions/pull/55.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
